### PR TITLE
COmmands' slash

### DIFF
--- a/include/main.pas
+++ b/include/main.pas
@@ -145,9 +145,9 @@ begin
   Bot.OnReceiveMessage := @Mesurement.DetectImperialMetric;
   with BOT do
   try
-    CommandHandlers['start']    := @CommandMessages.ShowStart;
-    CommandHandlers['help']     := @CommandMessages.ShowHelp;
-    CommandHandlers['currency'] := @CommandMessages.ConvertCurrency;
+    CommandHandlers['/start']    := @CommandMessages.ShowStart;
+    CommandHandlers['/help']     := @CommandMessages.ShowHelp;
+    CommandHandlers['/currency'] := @CommandMessages.ConvertCurrency;
   except
     On E: Exception do
       writeln('Error while creating commands: ' + E.Message);
@@ -291,12 +291,18 @@ procedure TCommandMessages.ShowStart(ASender: TObject; const ACommand: string;
   AMessage: TTelegramMessageObj);
 begin
   Bot.sendMessage(StartMessage);
+  { UpdateProcessed is a flag that the Update object is processed and there is no need for further processing
+      and for calling the appropriate events }
+  Bot.UpdateProcessed:=True; 
 end;
 
 procedure TCommandMessages.ShowHelp(ASender: TObject; const ACommand: string;
   AMessage: TTelegramMessageObj);
 begin
   Bot.sendMessage(HelpMessage);
+  { UpdateProcessed is a flag that the Update object is processed and there is no need for further processing
+      and for calling the appropriate events }
+  Bot.UpdateProcessed:=True; 
 end;
 
 procedure TCommandMessages.ConvertCurrency(ASender: TObject;


### PR DESCRIPTION
1) Commands must have a slash at the beginning in the text. 2) If you use both command callbacks and, for example, `OnReceiveMessage`, then you need to set the UpdateProcessed  flag to avoid double processing in both command callbacks and OnReceiveMessage callbacks